### PR TITLE
[숲 맵] Ghost Collision 문제 해결 (GroundLayer 하위의 Box Collider 수정)

### DIFF
--- a/Assets/Scenes/ForestMap.unity
+++ b/Assets/Scenes/ForestMap.unity
@@ -958,7 +958,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 96}
+  m_Size: {x: 30, y: 2, z: 95.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1 &89104580
 GameObject:
@@ -1003,7 +1003,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 40}
+  m_Size: {x: 30, y: 2, z: 39.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &95299830
 PrefabInstance:
@@ -2765,7 +2765,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 48}
+  m_Size: {x: 30, y: 2, z: 47.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &307902081
 PrefabInstance:
@@ -4007,7 +4007,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 48}
+  m_Size: {x: 30, y: 2, z: 47.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &418853204
 PrefabInstance:
@@ -4149,7 +4149,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 120, y: 2, z: 130}
+  m_Size: {x: 120, y: 2, z: 129.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!4 &423348510 stripped
 Transform:
@@ -6426,7 +6426,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 67.08}
+  m_Size: {x: 30, y: 2, z: 66.98}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1 &611710788
 GameObject:
@@ -6933,7 +6933,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 60}
+  m_Size: {x: 30, y: 2, z: 59.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!4 &672484438 stripped
 Transform:
@@ -7066,7 +7066,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 150}
+  m_Size: {x: 30, y: 2, z: 149.9}
   m_Center: {x: 1, y: -1, z: 25}
 --- !u!1001 &687211243
 PrefabInstance:
@@ -7818,7 +7818,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 70, y: 2, z: 80}
+  m_Size: {x: 70, y: 2, z: 79.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &817888795
 PrefabInstance:
@@ -9233,7 +9233,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 10}
+  m_Size: {x: 30, y: 2, z: 9.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1 &960605508
 GameObject:
@@ -9672,7 +9672,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 48}
+  m_Size: {x: 30, y: 2, z: 47.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &1002151538
 PrefabInstance:
@@ -12575,7 +12575,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 50}
+  m_Size: {x: 30, y: 2, z: 49.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &1393324218
 PrefabInstance:
@@ -13068,7 +13068,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 20}
+  m_Size: {x: 30, y: 2, z: 19.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &1410886149
 PrefabInstance:
@@ -15117,7 +15117,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 89.44}
+  m_Size: {x: 30, y: 2, z: 89.34}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &1585511329
 PrefabInstance:
@@ -15240,7 +15240,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 48}
+  m_Size: {x: 30, y: 2, z: 47.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &1589173328
 PrefabInstance:
@@ -16336,7 +16336,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 100, y: 2, z: 110}
+  m_Size: {x: 100, y: 2, z: 109.8}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!114 &1730581456 stripped
 MonoBehaviour:
@@ -17852,7 +17852,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 22.36}
+  m_Size: {x: 30, y: 2, z: 22.26}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &1976894629
 PrefabInstance:
@@ -18435,7 +18435,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 100, y: 2, z: 60}
+  m_Size: {x: 100, y: 2, z: 59.9}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &2041241652
 PrefabInstance:
@@ -19450,7 +19450,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 44.72}
+  m_Size: {x: 30, y: 2, z: 44.62}
   m_Center: {x: 0, y: -1, z: 0}
 --- !u!1001 &2129321930
 PrefabInstance:

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -1,7 +1,7 @@
 {
-  "m_Name": "Settings",
-  "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
-  "m_Dictionary": {
-    "m_DictionaryValues": []
-  }
+    "m_Name": "Settings",
+    "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
+    "m_Dictionary": {
+        "m_DictionaryValues": []
+    }
 }


### PR DESCRIPTION
# [숲 맵] Ghost Collision 문제 해결 (GroundLayer 하위의 Box Collider 수정)

## Related Issue(s)

https://2025springswppimo.slack.com/archives/C08J7PXTVFT/p1748251431179569

## PR Description

볼록인 경사면에서 짱구가 땅에 걸리듯이 통통 튀어오르는 문제를 해결하였다. 
Ghost Collision 문제라고 파악했기 때문에, 정확하게 붙어있는 GroundLayer의 Box Collider들에 대해서 각각의 Box Collider가 아주 미세하게 떨어져 있을 수 있게 GroundLayer의 하위 자식들의 Box Collider의 Z축 크기를 0.1 씩 줄였다.

### Changes Included

- [ ] Fixed identified bug(s): 숲 맵의 Ghost Collision 문제 해결

### Screenshots (if UI changes were made)

육안으로 BoxCollider의 크기를 0.1 씩 줄인 것을 확인할 수 없기 때문에 따로 스크린샷은 첨부하지 않았습니다.

### Notes for Reviewer

숲 맵 플레이 해보시면서 아직도 Ghost Collision 문제가 발생하는지 확인해주시면 감사하겠습니다.
(볼록진 경사면에서 짱구가 위로 통통 튀는 경우가 있는지 확인해주시면 됩니다.)

---

## Reviewer Checklist

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

---

## Additional Comments

본 PR의 실제 작업시간은 12분 정도 걸렸습니다. (0.2 hour)
