### PR TITLE
숲 맵 카메라 설정 및 프리팹 태그 수정 후 파티클 적용

### DIFF
--- a/Assets/LowPolyDungeonsLite/Prefabs/Ground_01.prefab
+++ b/Assets/LowPolyDungeonsLite/Prefabs/Ground_01.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 3444829864883919373}
   - component: {fileID: 4729723302331074421}
   - component: {fileID: 1563464522814601850}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Ground_01
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -29,6 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -52,6 +53,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/Bush/Bush_02.prefab
+++ b/Assets/MapResources/Bush/Bush_02.prefab
@@ -178,7 +178,7 @@ GameObject:
   - component: {fileID: 5531866383690190313}
   m_Layer: 0
   m_Name: Bush_02
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/MapResources/ForestMap/Prefabs/Branch_01.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Branch_01.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6840989815014681252}
   m_Layer: 0
   m_Name: Branch_01
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -29,6 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -52,6 +53,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/ForestMap/Prefabs/Bush_01.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Bush_01.prefab
@@ -154,7 +154,7 @@ GameObject:
   - component: {fileID: 577572581637733345}
   m_Layer: 0
   m_Name: Bush_01_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/MapResources/ForestMap/Prefabs/Bush_03.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Bush_03.prefab
@@ -154,7 +154,7 @@ GameObject:
   - component: {fileID: 5304575355203780508}
   m_Layer: 0
   m_Name: Bush_03_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/MapResources/ForestMap/Prefabs/Flowers_01.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Flowers_01.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6279495284966754123}
   m_Layer: 0
   m_Name: Flowers_01_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -29,6 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5186735023777053022}
   m_RootOrder: 0
@@ -52,6 +53,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -107,7 +109,7 @@ GameObject:
   - component: {fileID: 5777168012237853380}
   m_Layer: 0
   m_Name: Flowers_01
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -122,6 +124,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8005639462765410179}
   - {fileID: 3753148574503426463}
@@ -179,6 +182,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5186735023777053022}
   m_RootOrder: 1
@@ -202,6 +206,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/ForestMap/Prefabs/Flowers_02.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Flowers_02.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 2799740716385147855}
   m_Layer: 0
   m_Name: Flowers_02_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -29,6 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3899520030807063256}
   m_RootOrder: 0
@@ -52,6 +53,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -107,7 +109,7 @@ GameObject:
   - component: {fileID: 4496930816834818447}
   m_Layer: 0
   m_Name: Flowers_02
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -122,6 +124,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7546754162368725668}
   - {fileID: 2477855283117445636}
@@ -179,6 +182,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3899520030807063256}
   m_RootOrder: 1
@@ -202,6 +206,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/ForestMap/Prefabs/Grass_01.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Grass_01.prefab
@@ -28,6 +28,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8903058273634951509}
   m_RootOrder: 1
@@ -51,6 +52,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -95,7 +97,7 @@ GameObject:
   - component: {fileID: 3166200003208906893}
   m_Layer: 0
   m_Name: Grass_01_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -110,6 +112,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8903058273634951509}
   m_RootOrder: 0
@@ -133,6 +136,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -188,7 +192,7 @@ GameObject:
   - component: {fileID: 6757531004235149912}
   m_Layer: 0
   m_Name: Grass_01
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -203,6 +207,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8927922121296990005}
   - {fileID: 5690786719881562600}

--- a/Assets/MapResources/ForestMap/Prefabs/Grass_02.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Grass_02.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 43327879499130323}
   m_Layer: 0
   m_Name: Grass_02
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -27,6 +27,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7802349228523010499}
   - {fileID: 8657212444606450839}
@@ -70,7 +71,7 @@ GameObject:
   - component: {fileID: 8575057018571519246}
   m_Layer: 0
   m_Name: Grass_02_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -85,6 +86,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3356751432537613521}
   m_RootOrder: 0
@@ -108,6 +110,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -179,6 +182,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3356751432537613521}
   m_RootOrder: 1
@@ -202,6 +206,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/ForestMap/Prefabs/Ground_01.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Ground_01.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 2536002159034070635}
   m_Layer: 0
   m_Name: Ground_01
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -29,6 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -52,6 +53,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/ForestMap/Prefabs/Ground_02.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Ground_02.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 8484069592235595194}
   m_Layer: 0
   m_Name: Ground_02
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -29,6 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -52,6 +53,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/ForestMap/Prefabs/Ground_03.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Ground_03.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6179971859430226796}
   m_Layer: 0
   m_Name: Ground_03
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -29,6 +29,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -52,6 +53,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/ForestMap/Prefabs/Mushroom_01.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Mushroom_01.prefab
@@ -155,7 +155,7 @@ GameObject:
   - component: {fileID: 4741198870963217154}
   m_Layer: 0
   m_Name: Mushroom_01_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/MapResources/ForestMap/Prefabs/Mushroom_02.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Mushroom_02.prefab
@@ -154,7 +154,7 @@ GameObject:
   - component: {fileID: 5038574928522167449}
   m_Layer: 0
   m_Name: Mushroom_02_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/MapResources/ForestMap/Prefabs/Stump_01.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Stump_01.prefab
@@ -154,7 +154,7 @@ GameObject:
   - component: {fileID: 6049786131622086768}
   m_Layer: 0
   m_Name: Stump_01_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/MapResources/ForestMap/Prefabs/Tree_01.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Tree_01.prefab
@@ -28,6 +28,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2222111361405018444}
   m_RootOrder: 1
@@ -51,6 +52,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -93,7 +95,7 @@ GameObject:
   - component: {fileID: 230860312991076117}
   m_Layer: 0
   m_Name: Tree_01
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -108,6 +110,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6391492409923566826}
   - {fileID: 2016627034897836496}
@@ -151,7 +154,7 @@ GameObject:
   - component: {fileID: 6594968128082907717}
   m_Layer: 0
   m_Name: Tree_01_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -166,6 +169,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2222111361405018444}
   m_RootOrder: 0
@@ -189,6 +193,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/ForestMap/Prefabs/Tree_02.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Tree_02.prefab
@@ -28,6 +28,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4661435515762813124}
   m_RootOrder: 1
@@ -51,6 +52,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -110,6 +112,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4661435515762813124}
   m_RootOrder: 0
@@ -133,6 +136,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -188,7 +192,7 @@ GameObject:
   - component: {fileID: 7864700636845172665}
   m_Layer: 0
   m_Name: Tree_02
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -203,6 +207,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 990127138215673555}
   - {fileID: 3438630137501779417}

--- a/Assets/MapResources/ForestMap/Prefabs/Tree_03.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Tree_03.prefab
@@ -28,6 +28,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 880970725214738984}
   m_RootOrder: 1
@@ -51,6 +52,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -110,6 +112,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 880970725214738984}
   m_RootOrder: 0
@@ -133,6 +136,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -188,7 +192,7 @@ GameObject:
   - component: {fileID: 5096517541735811467}
   m_Layer: 0
   m_Name: Tree_03
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -203,6 +207,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4376338348109310597}
   - {fileID: 4175922834104611115}

--- a/Assets/MapResources/ForestMap/Prefabs/Tree_04.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Tree_04.prefab
@@ -28,6 +28,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2807449429036539767}
   m_RootOrder: 1
@@ -51,6 +52,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -93,7 +95,7 @@ GameObject:
   - component: {fileID: 5942433330446073732}
   m_Layer: 0
   m_Name: Tree_04
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -108,6 +110,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8687903930291284306}
   - {fileID: 1257895545969857279}
@@ -166,6 +169,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2807449429036539767}
   m_RootOrder: 0
@@ -189,6 +193,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/MapResources/ForestMap/Prefabs/Tree_05.prefab
+++ b/Assets/MapResources/ForestMap/Prefabs/Tree_05.prefab
@@ -28,6 +28,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9069115365609054727}
   m_RootOrder: 1
@@ -51,6 +52,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -92,10 +94,11 @@ GameObject:
   - component: {fileID: 5204263869384690163}
   - component: {fileID: 3981920650935114268}
   - component: {fileID: 8698415174464191407}
-  - component: {fileID: 503707795537676108}
+  - component: {fileID: 7743598402965617032}
+  - component: {fileID: 6554363574096436446}
   m_Layer: 0
   m_Name: Tree_05_LOD0
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -110,6 +113,7 @@ Transform:
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9069115365609054727}
   m_RootOrder: 0
@@ -133,6 +137,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -163,7 +168,7 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &503707795537676108
+--- !u!65 &7743598402965617032
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -174,8 +179,21 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1.5, y: 3.671553, z: 1.5}
-  m_Center: {x: 0, y: 1.8255256, z: 0}
+  m_Size: {x: 1.6364511, y: 2.886261, z: 1.6564779}
+  m_Center: {x: 0.25383848, y: 2.2181716, z: -0.0016908646}
+--- !u!65 &6554363574096436446
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5089877098680381616}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.4832466, y: 0.76830614, z: 0.4879449}
+  m_Center: {x: 0.014302865, y: 0.37390226, z: -0.003490828}
 --- !u!1 &9069115365609291303
 GameObject:
   m_ObjectHideFlags: 0
@@ -188,7 +206,7 @@ GameObject:
   - component: {fileID: 1282714561840611028}
   m_Layer: 0
   m_Name: Tree_05
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -203,6 +221,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5204263869384690163}
   - {fileID: 7762923490116116496}

--- a/Assets/Particles/Player/Prefebs/ObstacleCollision.prefab
+++ b/Assets/Particles/Player/Prefebs/ObstacleCollision.prefab
@@ -27,8 +27,8 @@ Transform:
   m_GameObject: {fileID: 6346714852332592797}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1.8, y: 1.8, z: 1.8}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 6346714852724921535}
   m_RootOrder: 1
@@ -4897,8 +4897,8 @@ Transform:
   m_GameObject: {fileID: 6346714852724921532}
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1.8, y: 1.8, z: 1.8}
+  m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 6346714853708958708}
   - {fileID: 6346714852332592798}
@@ -9769,8 +9769,8 @@ Transform:
   m_GameObject: {fileID: 6346714853708958699}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1.8, y: 1.8, z: 1.8}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 6346714852724921535}
   m_RootOrder: 0

--- a/Assets/Particles/Player/Prefebs/WallCollision.prefab
+++ b/Assets/Particles/Player/Prefebs/WallCollision.prefab
@@ -27,8 +27,8 @@ Transform:
   m_GameObject: {fileID: 1417311694538714054}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1.2, y: 1.2, z: 1.2}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 5911293329937986702}
   m_RootOrder: 0
@@ -4909,7 +4909,7 @@ Transform:
   m_GameObject: {fileID: 5178054290253232462}
   m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 1, z: 0}
-  m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
+  m_LocalScale: {x: 0.35, y: 0.35, z: 0.35}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 8357752333107012559}

--- a/Assets/Prefabs/CaveMapTile/1x1 Straight.prefab
+++ b/Assets/Prefabs/CaveMapTile/1x1 Straight.prefab
@@ -247,7 +247,7 @@ GameObject:
   - component: {fileID: 1788099077702158763}
   m_Layer: 0
   m_Name: LeftWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -361,7 +361,7 @@ GameObject:
   - component: {fileID: 6641786866854001256}
   m_Layer: 0
   m_Name: RightWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1811,6 +1811,10 @@ PrefabInstance:
     - target: {fileID: 916917378494744782, guid: 98f5378049f9b5745a77677f581b32b1, type: 3}
       propertyPath: m_Name
       value: Ground
+      objectReference: {fileID: 0}
+    - target: {fileID: 916917378494744782, guid: 98f5378049f9b5745a77677f581b32b1, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 1563464522814601850, guid: 98f5378049f9b5745a77677f581b32b1, type: 3}
       propertyPath: m_Enabled

--- a/Assets/Prefabs/CaveMapTile/45D_Corner.prefab
+++ b/Assets/Prefabs/CaveMapTile/45D_Corner.prefab
@@ -45,7 +45,7 @@ GameObject:
   - component: {fileID: 6589428410770106528}
   m_Layer: 0
   m_Name: CornerWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -166,7 +166,7 @@ GameObject:
   - component: {fileID: 7667208530138125922}
   m_Layer: 0
   m_Name: CornerWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/CaveMapTile/45D_Corner_Big.prefab
+++ b/Assets/Prefabs/CaveMapTile/45D_Corner_Big.prefab
@@ -272,7 +272,7 @@ GameObject:
   - component: {fileID: 4725750373182041984}
   m_Layer: 0
   m_Name: CornerWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -317,7 +317,7 @@ GameObject:
   - component: {fileID: 8106483031726133570}
   m_Layer: 0
   m_Name: CornerWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/CaveMapTile/4x1 DownHill.prefab
+++ b/Assets/Prefabs/CaveMapTile/4x1 DownHill.prefab
@@ -45,7 +45,7 @@ GameObject:
   - component: {fileID: 1233783788561840010}
   m_Layer: 0
   m_Name: RightWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -121,7 +121,7 @@ GameObject:
   - component: {fileID: 831747439225121706}
   m_Layer: 0
   m_Name: RightWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -237,7 +237,7 @@ GameObject:
   - component: {fileID: 2647186501407721350}
   m_Layer: 0
   m_Name: LeftWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -282,7 +282,7 @@ GameObject:
   - component: {fileID: 3857099530796494351}
   m_Layer: 0
   m_Name: RightWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -767,7 +767,7 @@ GameObject:
   - component: {fileID: 5725819740842186857}
   m_Layer: 0
   m_Name: LeftWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1040,7 +1040,7 @@ GameObject:
   - component: {fileID: 6188931624002307145}
   m_Layer: 0
   m_Name: LeftWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1763,7 +1763,7 @@ GameObject:
   - component: {fileID: 8177389868292808140}
   m_Layer: 0
   m_Name: LeftWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1902,7 +1902,7 @@ GameObject:
   - component: {fileID: 6935672399381017669}
   m_Layer: 0
   m_Name: RightWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/CaveMapTile/90D_Corner.prefab
+++ b/Assets/Prefabs/CaveMapTile/90D_Corner.prefab
@@ -45,7 +45,7 @@ GameObject:
   - component: {fileID: 5313074470811991113}
   m_Layer: 0
   m_Name: RightWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -129,7 +129,7 @@ GameObject:
   - component: {fileID: 61630907487731380}
   m_Layer: 0
   m_Name: LeftWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/CaveMapTile/90D_Corner_Big.prefab
+++ b/Assets/Prefabs/CaveMapTile/90D_Corner_Big.prefab
@@ -370,7 +370,7 @@ GameObject:
   - component: {fileID: 5877869941116661095}
   m_Layer: 0
   m_Name: CornerWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -415,7 +415,7 @@ GameObject:
   - component: {fileID: 5877869940308686480}
   m_Layer: 0
   m_Name: CornerWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -507,7 +507,7 @@ GameObject:
   - component: {fileID: 6955629453504432210}
   m_Layer: 0
   m_Name: CornerWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -552,7 +552,7 @@ GameObject:
   - component: {fileID: 6955629453235950501}
   m_Layer: 0
   m_Name: CornerWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/CaveMapTile/Room.prefab
+++ b/Assets/Prefabs/CaveMapTile/Room.prefab
@@ -200,7 +200,7 @@ GameObject:
   - component: {fileID: 2288703723256132397}
   m_Layer: 0
   m_Name: RightWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1471,7 +1471,7 @@ GameObject:
   - component: {fileID: 3543714060724749779}
   m_Layer: 0
   m_Name: ExitWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1685,7 +1685,7 @@ GameObject:
   - component: {fileID: 3543714061864357655}
   m_Layer: 0
   m_Name: EntryWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2695,7 +2695,7 @@ GameObject:
   - component: {fileID: 6575216685588955374}
   m_Layer: 0
   m_Name: LeftWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/ForestMapTile/1x1 Straight.prefab
+++ b/Assets/Prefabs/ForestMapTile/1x1 Straight.prefab
@@ -350,7 +350,7 @@ GameObject:
   - component: {fileID: 5786302758356142840}
   m_Layer: 0
   m_Name: Left_Wall
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -395,7 +395,7 @@ GameObject:
   - component: {fileID: 5786302758364310736}
   m_Layer: 0
   m_Name: Right_Wall
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -96,6 +96,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mixingCamera: {fileID: 0}
+  sectorName: []
 --- !u!114 &469998019989973565
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -124,7 +125,7 @@ Rigidbody:
   m_AngularDrag: 5
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 2
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 1
 --- !u!65 &444247440589350741

--- a/Assets/Prefabs/PlayerPrefeb.prefab
+++ b/Assets/Prefabs/PlayerPrefeb.prefab
@@ -918,6 +918,22 @@ PrefabInstance:
       propertyPath: itemUI.Array.data[2]
       value: 
       objectReference: {fileID: 1618759972486530034}
+    - target: {fileID: 1490184687973807735, guid: af94f4ad3c81efa48be9acc4062684d7, type: 3}
+      propertyPath: sectorName.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1490184687973807735, guid: af94f4ad3c81efa48be9acc4062684d7, type: 3}
+      propertyPath: sectorName.Array.data[0]
+      value: TrackSector1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1490184687973807735, guid: af94f4ad3c81efa48be9acc4062684d7, type: 3}
+      propertyPath: sectorName.Array.data[1]
+      value: RoomSector
+      objectReference: {fileID: 0}
+    - target: {fileID: 1490184687973807735, guid: af94f4ad3c81efa48be9acc4062684d7, type: 3}
+      propertyPath: sectorName.Array.data[2]
+      value: TrackSector2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: af94f4ad3c81efa48be9acc4062684d7, type: 3}
 --- !u!4 &3028419032764210384 stripped

--- a/Assets/Scenes/ForestMap.unity
+++ b/Assets/Scenes/ForestMap.unity
@@ -223,6 +223,63 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+--- !u!1 &11468888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 11468890}
+  - component: {fileID: 11468889}
+  m_Layer: 0
+  m_Name: Dolly Track (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &11468889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11468888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d37e5385efd7064cb1d54c94960acae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Resolution: 20
+  m_Appearance:
+    pathColor: {r: 0, g: 1, b: 0, a: 1}
+    inactivePathColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    width: 0.2
+  m_Looped: 0
+  m_Waypoints:
+  - position: {x: 155, y: -100, z: 1010}
+    tangent: {x: 10, y: 0, z: 0}
+    roll: 0
+  - position: {x: 185, y: -100, z: 1010}
+    tangent: {x: 10, y: 0, z: 0}
+    roll: 0
+--- !u!4 &11468890
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11468888}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 7, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 644104163}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &11609076
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1531,7 +1588,7 @@ MonoBehaviour:
   m_HorizontalDamping: 0.5
   m_VerticalDamping: 0.5
   m_ScreenX: 0.5
-  m_ScreenY: 0.5
+  m_ScreenY: 0.6
   m_DeadZoneWidth: 0
   m_DeadZoneHeight: 0
   m_SoftZoneWidth: 0.8
@@ -1552,12 +1609,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Path: {fileID: 1312869645}
-  m_PathPosition: 0.8535807
+  m_PathPosition: 0.019888029
   m_PositionUnits: 0
   m_PathOffset: {x: 0, y: 0, z: 0}
   m_XDamping: 0
   m_YDamping: 0
-  m_ZDamping: 0.75
+  m_ZDamping: 0.5
   m_CameraUp: 0
   m_PitchDamping: 0
   m_YawDamping: 0
@@ -1599,7 +1656,7 @@ Transform:
   - {fileID: 1476160509}
   - {fileID: 1525773533}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &175972319 stripped
 Transform:
@@ -2080,6 +2137,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fa2f201fb965c5b4aa284fc7f57a9e19, type: 3}
+--- !u!1 &228406174
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 228406175}
+  - component: {fileID: 228406176}
+  m_Layer: 0
+  m_Name: Sector2Center
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &228406175
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 228406174}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 106, y: -20, z: 480}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &228406176
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 228406174}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 2, y: 9, z: 14}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &229796637
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2850,6 +2952,51 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3500581970453440516, guid: 3286f81238c0c07409e6cf14ca23ca3d, type: 3}
   m_PrefabInstance: {fileID: 1692326737}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &317509087
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 317509088}
+  - component: {fileID: 317509089}
+  m_Layer: 0
+  m_Name: Sector2Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &317509088
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 317509087}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 115, y: -20, z: 473}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &317509089
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 317509087}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 14, y: 9, z: 2}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &321490756
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3099,6 +3246,51 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5786302758842860239, guid: fa2f201fb965c5b4aa284fc7f57a9e19, type: 3}
   m_PrefabInstance: {fileID: 330674527}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &356968164
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 356968165}
+  - component: {fileID: 356968166}
+  m_Layer: 0
+  m_Name: Sector2Center
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &356968165
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 356968164}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &356968166
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 356968164}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 18, y: 9, z: 2}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!4 &361751125 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3500581970453440516, guid: 3286f81238c0c07409e6cf14ca23ca3d, type: 3}
@@ -4217,6 +4409,107 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
+--- !u!1 &436001045
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 436001046}
+  - component: {fileID: 436001049}
+  - component: {fileID: 436001048}
+  - component: {fileID: 436001047}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &436001046
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436001045}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 540355535}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &436001047
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436001045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 418e42c7d0405cc48a7b83f63ea53bb3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Path: {fileID: 1552938196}
+  m_PathPosition: -0.15
+  m_PositionUnits: 0
+  m_PathOffset: {x: 0, y: 0, z: 0}
+  m_XDamping: 0
+  m_YDamping: 0
+  m_ZDamping: 0.5
+  m_CameraUp: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AutoDolly:
+    m_Enabled: 1
+    m_PositionOffset: -0.15
+    m_SearchRadius: 2
+    m_SearchResolution: 5
+--- !u!114 &436001048
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436001045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.6
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &436001049
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436001045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &439623775
 GameObject:
   m_ObjectHideFlags: 0
@@ -4283,7 +4576,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &441058814
 PrefabInstance:
@@ -4615,7 +4908,6 @@ GameObject:
   m_Component:
   - component: {fileID: 467121503}
   - component: {fileID: 467121504}
-  - component: {fileID: 467121505}
   m_Layer: 0
   m_Name: Virtual Camera
   m_TagString: Untagged
@@ -4630,14 +4922,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 467121502}
-  m_LocalRotation: {x: 0.26932624, y: -0.0023905025, z: 0.00066853, w: 0.96304584}
-  m_LocalPosition: {x: 0.02618116, y: 7, z: -5.273693}
+  m_LocalRotation: {x: 0.2536577, y: 1.1044959e-14, z: -3.4487501e-15, w: 0.9672941}
+  m_LocalPosition: {x: 8.309197, y: 130.35262, z: -486.202}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 166272210}
-  m_Father: {fileID: 644104163}
-  m_RootOrder: 2
+  m_Father: {fileID: 1417995265}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: -18.435, z: 161.265}
 --- !u!114 &467121504
 MonoBehaviour:
@@ -4677,49 +4969,6 @@ MonoBehaviour:
         m_Calls: []
   m_LegacyBlendHint: 0
   m_ComponentOwner: {fileID: 166272210}
---- !u!20 &467121505
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 467121502}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
 --- !u!1001 &471571342
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4994,7 +5243,7 @@ Transform:
   - {fileID: 1416013524}
   - {fileID: 913459566}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &487937727
 PrefabInstance:
@@ -5455,6 +5704,107 @@ Transform:
   m_Father: {fileID: 611710789}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &524703086
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 524703087}
+  - component: {fileID: 524703090}
+  - component: {fileID: 524703089}
+  - component: {fileID: 524703088}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &524703087
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 524703086}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1083382881}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &524703088
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 524703086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 418e42c7d0405cc48a7b83f63ea53bb3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Path: {fileID: 944142065}
+  m_PathPosition: -0.15
+  m_PositionUnits: 0
+  m_PathOffset: {x: 0, y: 0, z: 0}
+  m_XDamping: 0
+  m_YDamping: 0
+  m_ZDamping: 0.5
+  m_CameraUp: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AutoDolly:
+    m_Enabled: 1
+    m_PositionOffset: -0.15
+    m_SearchRadius: 2
+    m_SearchResolution: 5
+--- !u!114 &524703089
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 524703086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.6
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &524703090
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 524703086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &525180293 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
@@ -5900,6 +6250,77 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+--- !u!1 &540355534
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 540355535}
+  - component: {fileID: 540355536}
+  m_Layer: 0
+  m_Name: Virtual Camera (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &540355535
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540355534}
+  m_LocalRotation: {x: -0.0010630456, y: 0.99016136, z: 0.13972364, w: 0.007533399}
+  m_LocalPosition: {x: 1.3091974, y: 50.357727, z: -21.800537}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 436001046}
+  m_Father: {fileID: 1417995265}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: -18.435, z: 161.265}
+--- !u!114 &540355536
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540355534}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 1382102154}
+  m_Follow: {fileID: 1382102154}
+  m_Lens:
+    FieldOfView: 60.000004
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 436001046}
 --- !u!4 &548586979 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
@@ -6461,7 +6882,7 @@ Transform:
   - {fileID: 2093031541}
   - {fileID: 2120034250}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &617623333
 PrefabInstance:
@@ -6742,9 +7163,14 @@ Transform:
   m_Children:
   - {fileID: 2052544697}
   - {fileID: 1312869646}
-  - {fileID: 467121503}
+  - {fileID: 1247372958}
+  - {fileID: 1552938195}
+  - {fileID: 944142066}
+  - {fileID: 11468890}
+  - {fileID: 1254450306}
+  - {fileID: 1417995265}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &655270074
 PrefabInstance:
@@ -6915,7 +7341,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 664326923}
   m_LocalRotation: {x: 0, y: -0.42261827, z: 0, w: 0.9063079}
-  m_LocalPosition: {x: -26.18, y: 0, z: 12.01}
+  m_LocalPosition: {x: -26.18, y: -0.00001, z: 12.01}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -7048,7 +7474,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 685270753}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -7.9, y: -79.9999, z: 440}
+  m_LocalPosition: {x: -7.9, y: -80, z: 440}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -7402,7 +7828,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!120 &738819383
 LineRenderer:
   m_ObjectHideFlags: 0
@@ -7910,6 +8336,51 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 108507113624698413, guid: eebb56c82efbd8d4bb0eb6bd925a0e9d, type: 3}
   m_PrefabInstance: {fileID: 774108619}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &794341853
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 794341854}
+  - component: {fileID: 794341855}
+  m_Layer: 0
+  m_Name: Sector2Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &794341854
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794341853}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -7, y: 0, z: -2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &794341855
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794341853}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 2, y: 9, z: 22}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &801169137
 GameObject:
   m_ObjectHideFlags: 0
@@ -8508,7 +8979,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 898653051}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -8895,8 +9366,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 898653051}
-  - component: {fileID: 898653053}
-  - component: {fileID: 898653052}
   m_Layer: 5
   m_Name: RacePanel
   m_TagString: Untagged
@@ -8908,6 +9377,26 @@ GameObject:
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 898653050}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 912978594}
+  - {fileID: 858850918}
+  - {fileID: 1980293727}
+  - {fileID: 1081587542}
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!4 &898908358 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
@@ -8949,7 +9438,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 898653051}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -9314,6 +9803,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 223773212}
     m_Modifications:
+    - target: {fileID: 595144264497226264, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1062822144878683473, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1248108900779744634, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
       propertyPath: m_LocalScale.x
       value: 1
@@ -9668,13 +10165,121 @@ RectTransform:
   m_Children:
   - {fileID: 745276657}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 960, y: 540}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &944142064
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 944142066}
+  - component: {fileID: 944142065}
+  m_Layer: 0
+  m_Name: Dolly Track (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &944142065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944142064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d37e5385efd7064cb1d54c94960acae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Resolution: 20
+  m_Appearance:
+    pathColor: {r: 0, g: 1, b: 0, a: 1}
+    inactivePathColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    width: 0.2
+  m_Looped: 0
+  m_Waypoints:
+  - position: {x: -7, y: -80, z: 460}
+    tangent: {x: 0, y: 0, z: 20}
+    roll: 0
+  - position: {x: 10, y: -80, z: 496}
+    tangent: {x: 7.66, y: 0, z: 6.43}
+    roll: 0
+  - position: {x: 31, y: -80, z: 513}
+    tangent: {x: 7.66, y: 0, z: 6.43}
+    roll: 0
+  - position: {x: 52, y: -80, z: 530}
+    tangent: {x: 7.66, y: 0, z: 6.43}
+    roll: 0
+  - position: {x: 59, y: -87, z: 553}
+    tangent: {x: 0, y: -4, z: 8}
+    roll: 0
+  - position: {x: 59, y: -98, z: 575}
+    tangent: {x: 0, y: -4, z: 8}
+    roll: 0
+  - position: {x: 59, y: -100, z: 608}
+    tangent: {x: 0, y: 0, z: 12}
+    roll: 0
+  - position: {x: 59, y: -100, z: 645}
+    tangent: {x: 0, y: 0, z: 12}
+    roll: 0
+  - position: {x: 57, y: -100, z: 680}
+    tangent: {x: 0, y: 0, z: 12}
+    roll: 0
+  - position: {x: 69, y: -100, z: 711}
+    tangent: {x: 8.6666, y: 0, z: 10.333}
+    roll: 0
+  - position: {x: 97, y: -100, z: 740}
+    tangent: {x: 8.6666, y: 0, z: 10.333}
+    roll: 0
+  - position: {x: 107, y: -100, z: 770}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: 107, y: -100, z: 800}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: 107, y: -100, z: 830}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: 107, y: -100, z: 860}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: 107, y: -100, z: 890}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: 107, y: -100, z: 920}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: 107, y: -100, z: 950}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: 112, y: -100, z: 980}
+    tangent: {x: 6.37, y: 0, z: 7.71}
+    roll: 0
+--- !u!4 &944142066
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944142064}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 7, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 644104163}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &953066133 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
@@ -9725,6 +10330,51 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 30, y: 2, z: 9.9}
   m_Center: {x: 0, y: -1, z: 0}
+--- !u!1 &959042944
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 959042945}
+  - component: {fileID: 959042946}
+  m_Layer: 0
+  m_Name: Sector2Center
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &959042945
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959042944}
+  m_LocalRotation: {x: 0, y: -0.42261827, z: 0, w: 0.9063079}
+  m_LocalPosition: {x: 122, y: -20, z: 493}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: -50, z: 0}
+--- !u!65 &959042946
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959042944}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 2, y: 9, z: 14}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &960605508
 GameObject:
   m_ObjectHideFlags: 0
@@ -10612,6 +11262,90 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
   m_PrefabInstance: {fileID: 1853226051}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1056385603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1056385606}
+  - component: {fileID: 1056385605}
+  - component: {fileID: 1056385604}
+  m_Layer: 0
+  m_Name: ParticleManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1056385604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1056385603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 97afe5d2c47487b4daf45e9638559183, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isRun: 0
+  runTime: 0
+  ranking:
+    Map1: []
+    Map2: []
+--- !u!114 &1056385605
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1056385603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1160ae63bb895b842b53fea5b0595bc4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  particles:
+  - name: WallCollision
+    particle: {fileID: 4055362527163186362, guid: 48a968da012a86a4283ad20986dea331, type: 3}
+    count: 1
+  - name: PlayerMove
+    particle: {fileID: 3381476127840034363, guid: b78a7d8231af6ea4cb4fedb9150b49e9, type: 3}
+    count: 11
+  - name: ObstacleCollision
+    particle: {fileID: 6346714852724921534, guid: f9e7f93f22bcfc64bbcaf2a57ee9deaf, type: 3}
+    count: 1
+  - name: MonkeyCollision
+    particle: {fileID: 4035903591278710482, guid: aa122f157eac1c8428ae5db8a315ccd8, type: 3}
+    count: 3
+  - name: ItemCollision
+    particle: {fileID: 9169966119468206341, guid: ed962e35f7fa6f34f8d27aa6d19ea293, type: 3}
+    count: 3
+  - name: UseItem
+    particle: {fileID: 6532625474870085668, guid: 07a977963523b3b4dbcaa27119f6b469, type: 3}
+    count: 2
+  - name: ClearMap
+    particle: {fileID: 9169966119468206341, guid: 2e429de3457c8a44386f5f8568392ebd, type: 3}
+    count: 1
+--- !u!4 &1056385606
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1056385603}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.71034753, y: -6.8643274, z: 7.88626}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1062084266
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11284,7 +12018,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 898653051}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -11329,6 +12063,77 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1081587541}
   m_CullTransparentMesh: 1
+--- !u!1 &1083382880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1083382881}
+  - component: {fileID: 1083382882}
+  m_Layer: 0
+  m_Name: Virtual Camera (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1083382881
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1083382880}
+  m_LocalRotation: {x: -0.0010630456, y: 0.99016136, z: 0.13972364, w: 0.007533399}
+  m_LocalPosition: {x: 1.3091974, y: 50.357727, z: -21.800537}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 524703087}
+  m_Father: {fileID: 1417995265}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: -18.435, z: 161.265}
+--- !u!114 &1083382882
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1083382880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 1382102154}
+  m_Follow: {fileID: 1382102154}
+  m_Lens:
+    FieldOfView: 60.000004
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 524703087}
 --- !u!1001 &1091564141
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11386,6 +12191,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9366b62bb219d8a4d98a0bf7deaa2759, type: 3}
+--- !u!1 &1103013850
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1103013851}
+  - component: {fileID: 1103013852}
+  m_Layer: 0
+  m_Name: Sector2Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1103013851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1103013850}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 142, y: -20, z: 520}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1103013852
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1103013850}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 30, y: 9, z: 14}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!4 &1110652589 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
@@ -11671,6 +12521,51 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
   m_PrefabInstance: {fileID: 1437141884}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1162260802
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1162260803}
+  - component: {fileID: 1162260804}
+  m_Layer: 0
+  m_Name: Sector1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1162260803
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1162260802}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -24}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1162260804
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1162260802}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 18, y: 9, z: 2}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &1175715584
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12033,11 +12928,211 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4385080170327957909, guid: ff62b58c5a9ea164fa8ddf8038e10cd1, type: 3}
   m_PrefabInstance: {fileID: 1002151538}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1246017771
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1246017772}
+  - component: {fileID: 1246017773}
+  m_Layer: 0
+  m_Name: Sector2Center
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1246017772
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1246017771}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 137, y: -20, z: 512}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1246017773
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1246017771}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 18, y: 9, z: 2}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1247372957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1247372958}
+  - component: {fileID: 1247372959}
+  m_Layer: 0
+  m_Name: Dolly Track (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1247372958
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1247372957}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 7, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 644104163}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1247372959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1247372957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d37e5385efd7064cb1d54c94960acae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Resolution: 20
+  m_Appearance:
+    pathColor: {r: 0, g: 1, b: 0, a: 1}
+    inactivePathColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    width: 0.2
+  m_Looped: 0
+  m_Waypoints:
+  - position: {x: -7, y: -80, z: 460}
+    tangent: {x: 0, y: 0, z: 20}
+    roll: 0
+  - position: {x: -24, y: -80, z: 494}
+    tangent: {x: -7.66, y: 0, z: 6.43}
+    roll: 0
+  - position: {x: -47, y: -80, z: 514}
+    tangent: {x: -7.66, y: 0, z: 6.43}
+    roll: 0
+  - position: {x: -70, y: -89, z: 534}
+    tangent: {x: -7.66, y: -5.77, z: 6.43}
+    roll: 0
+  - position: {x: -93, y: -100, z: 565}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -90, y: -100, z: 610}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -90, y: -100, z: 655}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -90, y: -100, z: 700}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -90, y: -100, z: 745}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -90, y: -100, z: 790}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -90, y: -100, z: 835}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -90, y: -100, z: 880}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -90, y: -100, z: 925}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -93, y: -100, z: 965}
+    tangent: {x: 0, y: 0, z: 15}
+    roll: 0
+  - position: {x: -78, y: -100, z: 998}
+    tangent: {x: 10, y: 0, z: 10}
+    roll: 0
+  - position: {x: -40, y: -100, z: 1012}
+    tangent: {x: 15, y: 0, z: 0}
+    roll: 0
+  - position: {x: 5, y: -100, z: 1010}
+    tangent: {x: 15, y: 0, z: 0}
+    roll: 0
+  - position: {x: 50, y: -100, z: 1010}
+    tangent: {x: 15, y: 0, z: 0}
+    roll: 0
+  - position: {x: 95, y: -100, z: 1010}
+    tangent: {x: 15, y: 0, z: 0}
+    roll: 0
+  - position: {x: 125, y: -100, z: 1010}
+    tangent: {x: 10, y: 0, z: 0}
+    roll: 0
+  - position: {x: 155, y: -100, z: 1010}
+    tangent: {x: 10, y: 0, z: 0}
+    roll: 0
 --- !u!4 &1249662089 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
   m_PrefabInstance: {fileID: 134532416}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1254450305
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1254450306}
+  m_Layer: 0
+  m_Name: TrackSelector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1254450306
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1254450305}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -7, y: -72, z: 490}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1162260803}
+  - {fileID: 794341854}
+  - {fileID: 356968165}
+  - {fileID: 1877966914}
+  - {fileID: 959042945}
+  - {fileID: 228406175}
+  - {fileID: 317509088}
+  - {fileID: 1246017772}
+  - {fileID: 1103013851}
+  - {fileID: 1828610575}
+  m_Father: {fileID: 644104163}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1265974371
 GameObject:
   m_ObjectHideFlags: 0
@@ -12504,110 +13599,53 @@ MonoBehaviour:
     width: 0.2
   m_Looped: 0
   m_Waypoints:
-  - position: {x: 0.27805233, y: 0, z: -27.579672}
-    tangent: {x: 0.18294811, y: 0, z: 9.0284195}
+  - position: {x: 0, y: 0, z: -5}
+    tangent: {x: 0, y: 0, z: 10}
     roll: 0
-  - position: {x: 0, y: 0, z: 0}
-    tangent: {x: 0, y: 0, z: 13.02536}
+  - position: {x: 0, y: -8, z: 23}
+    tangent: {x: 0, y: -3.66, z: 6.34}
     roll: 0
-  - position: {x: 0, y: -8.504108, z: 27.116049}
-    tangent: {x: -0.5305865, y: -6.403941, z: 9.217293}
+  - position: {x: 0, y: -20, z: 55}
+    tangent: {x: 0, y: 0, z: 10}
     roll: 0
-  - position: {x: 0.049774885, y: -16.364426, z: 55.808334}
-    tangent: {x: -0.22389674, y: 0.29002762, z: 8.721985}
+  - position: {x: 0, y: -13, z: 75}
+    tangent: {x: 0, y: 2.93, z: 5.07}
     roll: 0
-  - position: {x: -0.07427508, y: -11.02495, z: 74.789696}
-    tangent: {x: -0.06081915, y: 3.5080261, z: 5.992218}
+  - position: {x: -2, y: -10, z: 104}
+    tangent: {x: 0, y: 0, z: 12}
     roll: 0
-  - position: {x: 0.31910515, y: -8.506699, z: 104.22574}
-    tangent: {x: 0.1759634, y: -0.58693695, z: 6.9061203}
+  - position: {x: 10, y: -10, z: 139}
+    tangent: {x: 7.32, y: 0, z: 12.68}
     roll: 0
-  - position: {x: 9.4286175, y: -10.232187, z: 138.63101}
-    tangent: {x: 8.441999, y: 0, z: 12.939178}
+  - position: {x: 18, y: -10, z: 174}
+    tangent: {x: 0, y: 0, z: 12}
     roll: 0
-  - position: {x: 18.74079, y: -9.78673, z: 171.53336}
-    tangent: {x: 0.1610527, y: 0, z: 14.514435}
+  - position: {x: 18, y: -18, z: 211}
+    tangent: {x: 0, y: -4.76, z: 8.24}
     roll: 0
-  - position: {x: 19.120968, y: -16.027454, z: 211.1783}
-    tangent: {x: 0, y: -4.975897, z: 8.891983}
+  - position: {x: 18, y: -36, z: 246}
+    tangent: {x: 0, y: -4.76, z: 8.24}
     roll: 0
-  - position: {x: 19.245968, y: -34.591133, z: 245.73967}
-    tangent: {x: 0.007827759, y: -8.224968, z: 14.097061}
+  - position: {x: 18, y: -50, z: 286}
+    tangent: {x: 0, y: 0, z: 10}
     roll: 0
-  - position: {x: 18.683107, y: -48.755043, z: 282.66296}
-    tangent: {x: -0.38788033, y: 0, z: 7.2123413}
+  - position: {x: 5, y: -50, z: 312}
+    tangent: {x: -7, y: 0, z: 7}
     roll: 0
-  - position: {x: 7.9561186, y: -48.74829, z: 309.6878}
-    tangent: {x: -10.047266, y: 0, z: 9.181915}
+  - position: {x: -7, y: -55, z: 345}
+    tangent: {x: 0, y: -4.76, z: 8.24}
     roll: 0
-  - position: {x: -10.295482, y: -54.346725, z: 344.75967}
-    tangent: {x: 1.0270758, y: -8.333641, z: 15.743439}
+  - position: {x: -7, y: -73, z: 380}
+    tangent: {x: 0, y: -4.76, z: 8.24}
     roll: 0
-  - position: {x: -9.295482, y: -73.51984, z: 380.1375}
-    tangent: {x: 0, y: -7.464142, z: 15.420593}
+  - position: {x: -7, y: -80, z: 420}
+    tangent: {x: 0, y: 0, z: 13.33}
     roll: 0
-  - position: {x: -9.170482, y: -80.81632, z: 423.58646}
-    tangent: {x: 0.0048856735, y: -0.53182983, z: 22.655273}
+  - position: {x: -7, y: -80, z: 460}
+    tangent: {x: 0, y: 0, z: 13.33}
     roll: 0
-  - position: {x: -8.858982, y: -80.48814, z: 459.03482}
-    tangent: {x: 0.023430824, y: 0.040542603, z: 21.301239}
-    roll: 0
-  - position: {x: -24.053848, y: -79.50695, z: 496.00854}
-    tangent: {x: -9.610973, y: 0, z: 7.6354675}
-    roll: 0
-  - position: {x: -46.504787, y: -79.56151, z: 513.6477}
-    tangent: {x: -9.610973, y: -0.047584534, z: 7.7000732}
-    roll: 0
-  - position: {x: -68.09586, y: -86.86747, z: 530.3243}
-    tangent: {x: -8.1872635, y: -5.4314346, z: 7.7000732}
-    roll: 0
-  - position: {x: -81.87296, y: -96.43479, z: 542.8663}
-    tangent: {x: -6.3177567, y: -5.4314346, z: 5.538574}
-    roll: 0
-  - position: {x: -91.10184, y: -100.455864, z: 567.30634}
-    tangent: {x: 0, y: 0, z: 15}
-    roll: 0
-  - position: {x: -91.07493, y: -100.455864, z: 608.5572}
-    tangent: {x: 0, y: 0, z: 15}
-    roll: 0
-  - position: {x: -91.02033, y: -100.455864, z: 656.647}
-    tangent: {x: 0, y: 0, z: 15}
-    roll: 0
-  - position: {x: -90.993965, y: -100.455864, z: 701.8615}
-    tangent: {x: 0, y: 0, z: 15}
-    roll: 0
-  - position: {x: -90.782875, y: -100.455864, z: 750.25543}
-    tangent: {x: 0, y: 0, z: 15}
-    roll: 0
-  - position: {x: -90.746216, y: -100.455864, z: 800.5497}
-    tangent: {x: 0, y: 0, z: 15}
-    roll: 0
-  - position: {x: -90.71707, y: -100.455864, z: 848.5716}
-    tangent: {x: 0, y: 0, z: 15}
-    roll: 0
-  - position: {x: -90.682396, y: -100.455864, z: 901.9728}
-    tangent: {x: 0, y: 0, z: 15}
-    roll: 0
-  - position: {x: -90.753624, y: -100.455864, z: 953.19543}
-    tangent: {x: 0, y: 0, z: 15}
-    roll: 0
-  - position: {x: -75.57142, y: -100.455864, z: 995.75946}
-    tangent: {x: 17.86428, y: 0, z: 18.657654}
-    roll: 0
-  - position: {x: -34.42032, y: -100.455864, z: 1011.1622}
-    tangent: {x: 15.264589, y: 0, z: 0}
-    roll: 0
-  - position: {x: 8.13126, y: -100.455864, z: 1011.232}
-    tangent: {x: 15.264589, y: 0, z: 0}
-    roll: 0
-  - position: {x: 52.0041, y: -100.455864, z: 1011.0084}
-    tangent: {x: 15.264589, y: 0, z: 0}
-    roll: 0
-  - position: {x: 103.219666, y: -100.455864, z: 1010.7462}
-    tangent: {x: 15.264589, y: 0, z: 0}
-    roll: 0
-  - position: {x: 152.84042, y: -100.455864, z: 1010.5693}
-    tangent: {x: 15.264589, y: 0, z: 0}
+  - position: {x: -7, y: -80, z: 490}
+    tangent: {x: 0, y: 0, z: 10}
     roll: 0
 --- !u!4 &1312869646
 Transform:
@@ -13803,6 +14841,69 @@ Transform:
   m_Father: {fileID: 485074358}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1417995264
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1417995265}
+  - component: {fileID: 1417995266}
+  m_Layer: 0
+  m_Name: Mixing Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1417995265
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417995264}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -8.309197, y: -123.35773, z: 481.80054}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 467121503}
+  - {fileID: 1638625761}
+  - {fileID: 540355535}
+  - {fileID: 1083382881}
+  - {fileID: 2000383820}
+  m_Father: {fileID: 644104163}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1417995266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417995264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c26251a3e1f5ac41afa5ffb404c5f71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_Weight0: 1
+  m_Weight1: 0
+  m_Weight2: 0
+  m_Weight3: 0
+  m_Weight4: 0
+  m_Weight5: 0.5
+  m_Weight6: 0.5
+  m_Weight7: 0.5
 --- !u!1 &1418951733
 GameObject:
   m_ObjectHideFlags: 0
@@ -13895,7 +14996,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!4 &1427066195 stripped
 Transform:
@@ -15301,6 +16402,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 223773212}
     m_Modifications:
+    - target: {fileID: 5505349619167663956, guid: fa2f201fb965c5b4aa284fc7f57a9e19, type: 3}
+      propertyPath: m_LODs.Array.data[0].screenRelativeHeight
+      value: 0.052795753
+      objectReference: {fileID: 0}
     - target: {fileID: 5786302758356142840, guid: fa2f201fb965c5b4aa284fc7f57a9e19, type: 3}
       propertyPath: m_Size.x
       value: 2
@@ -15573,6 +16678,129 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3286f81238c0c07409e6cf14ca23ca3d, type: 3}
+--- !u!1 &1552938194
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1552938195}
+  - component: {fileID: 1552938196}
+  m_Layer: 0
+  m_Name: Dolly Track (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1552938195
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1552938194}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 7, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 644104163}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1552938196
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1552938194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d37e5385efd7064cb1d54c94960acae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Resolution: 20
+  m_Appearance:
+    pathColor: {r: 0, g: 1, b: 0, a: 1}
+    inactivePathColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    width: 0.2
+  m_Looped: 0
+  m_Waypoints:
+  - position: {x: -7, y: -80, z: 460}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -80, z: 490}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -80, z: 520}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -85, z: 550}
+    tangent: {x: 0, y: -5, z: 10}
+    roll: 0
+  - position: {x: -7, y: -100, z: 580}
+    tangent: {x: 0, y: -5, z: 10}
+    roll: 0
+  - position: {x: -7, y: -115, z: 610}
+    tangent: {x: 0, y: -5, z: 10}
+    roll: 0
+  - position: {x: -7, y: -120, z: 640}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -110, z: 680}
+    tangent: {x: 0, y: 5, z: 10}
+    roll: 0
+  - position: {x: -7, y: -100, z: 705}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -100, z: 735}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -110, z: 760}
+    tangent: {x: 0, y: -5, z: 10}
+    roll: 0
+  - position: {x: -7, y: -120, z: 785}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -120, z: 815}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -110, z: 840}
+    tangent: {x: 0, y: 5, z: 10}
+    roll: 0
+  - position: {x: -7, y: -100, z: 870}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -100, z: 900}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: -7, y: -100, z: 930}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
+  - position: {x: 5, y: -100, z: 956}
+    tangent: {x: 7, y: 0, z: 8}
+    roll: 0
+  - position: {x: 29, y: -100, z: 971}
+    tangent: {x: 10, y: 0, z: 0}
+    roll: 0
+  - position: {x: 59, y: -100, z: 971}
+    tangent: {x: 10, y: 0, z: 0}
+    roll: 0
+  - position: {x: 89, y: -100, z: 971}
+    tangent: {x: 10, y: 0, z: 0}
+    roll: 0
+  - position: {x: 112, y: -100, z: 980}
+    tangent: {x: 6.37, y: 0, z: 7.71}
+    roll: 0
+  - position: {x: 130, y: -100, z: 1002}
+    tangent: {x: 6.37, y: 0, z: 7.71}
+    roll: 0
+  - position: {x: 155, y: -100, z: 1010}
+    tangent: {x: 10, y: 0, z: 0}
+    roll: 0
 --- !u!4 &1563234906 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
@@ -15982,6 +17210,107 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
+--- !u!1 &1595193568
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1595193569}
+  - component: {fileID: 1595193572}
+  - component: {fileID: 1595193571}
+  - component: {fileID: 1595193570}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1595193569
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1595193568}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1638625761}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1595193570
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1595193568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 418e42c7d0405cc48a7b83f63ea53bb3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Path: {fileID: 1247372959}
+  m_PathPosition: -0.15
+  m_PositionUnits: 0
+  m_PathOffset: {x: 0, y: 0, z: 0}
+  m_XDamping: 0
+  m_YDamping: 0
+  m_ZDamping: 0.5
+  m_CameraUp: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AutoDolly:
+    m_Enabled: 1
+    m_PositionOffset: -0.15
+    m_SearchRadius: 2
+    m_SearchResolution: 5
+--- !u!114 &1595193571
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1595193568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.6
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &1595193572
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1595193568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1605208441
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16368,6 +17697,77 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5440707293445741943, guid: 494f6d43e170e9145bc7865d243ee00b, type: 3}
   m_PrefabInstance: {fileID: 1636240339}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1638625760
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1638625761}
+  - component: {fileID: 1638625762}
+  m_Layer: 0
+  m_Name: Virtual Camera (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1638625761
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638625760}
+  m_LocalRotation: {x: -0.0010630456, y: 0.99016136, z: 0.13972364, w: 0.007533399}
+  m_LocalPosition: {x: 1.3091974, y: 50.357727, z: -21.800537}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1595193569}
+  m_Father: {fileID: 1417995265}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: -18.435, z: 161.265}
+--- !u!114 &1638625762
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638625760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 1382102154}
+  m_Follow: {fileID: 1382102154}
+  m_Lens:
+    FieldOfView: 60.000004
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 1595193569}
 --- !u!1001 &1639021620
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16699,6 +18099,107 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 38335279662569219, guid: 34d3f526198dae440bb2ce6005d86055, type: 3}
   m_PrefabInstance: {fileID: 1655150827}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1666752481
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1666752482}
+  - component: {fileID: 1666752485}
+  - component: {fileID: 1666752484}
+  - component: {fileID: 1666752483}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1666752482
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1666752481}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2000383820}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1666752483
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1666752481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 418e42c7d0405cc48a7b83f63ea53bb3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Path: {fileID: 11468889}
+  m_PathPosition: -0.15
+  m_PositionUnits: 0
+  m_PathOffset: {x: 0, y: 0, z: 0}
+  m_XDamping: 0
+  m_YDamping: 0
+  m_ZDamping: 0.5
+  m_CameraUp: 0
+  m_PitchDamping: 0
+  m_YawDamping: 0
+  m_RollDamping: 0
+  m_AutoDolly:
+    m_Enabled: 1
+    m_PositionOffset: -0.15
+    m_SearchRadius: 2
+    m_SearchResolution: 5
+--- !u!114 &1666752484
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1666752481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_HorizontalDamping: 0.5
+  m_VerticalDamping: 0.5
+  m_ScreenX: 0.5
+  m_ScreenY: 0.6
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+--- !u!114 &1666752485
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1666752481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1692326737
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17414,7 +18915,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 108507113624698413, guid: eebb56c82efbd8d4bb0eb6bd925a0e9d, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 108507113624698413, guid: eebb56c82efbd8d4bb0eb6bd925a0e9d, type: 3}
       propertyPath: m_LocalScale.x
@@ -17512,6 +19013,51 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
   m_PrefabInstance: {fileID: 601845681}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1828610574
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1828610575}
+  - component: {fileID: 1828610576}
+  m_Layer: 0
+  m_Name: Sector3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828610575
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828610574}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 168, y: -20, z: 520}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1828610576
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1828610574}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 2, y: 9, z: 14}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &1843294652
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17533,7 +19079,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8783306491909106419, guid: f02116c209ecd9e488fc4d2cd8996133, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8783306491909106419, guid: f02116c209ecd9e488fc4d2cd8996133, type: 3}
       propertyPath: m_LocalScale.x
@@ -17603,7 +19149,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 108507113624698413, guid: eebb56c82efbd8d4bb0eb6bd925a0e9d, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 108507113624698413, guid: eebb56c82efbd8d4bb0eb6bd925a0e9d, type: 3}
       propertyPath: m_LocalScale.x
@@ -17746,6 +19292,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
+--- !u!1 &1877966913
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1877966914}
+  - component: {fileID: 1877966915}
+  m_Layer: 0
+  m_Name: Sector2Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1877966914
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877966913}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7, y: 0, z: -2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1254450306}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1877966915
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877966913}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 2, y: 9, z: 22}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!4 &1890298856 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3500581970453440516, guid: 3286f81238c0c07409e6cf14ca23ca3d, type: 3}
@@ -18508,7 +20099,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 898653051}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -18688,6 +20279,77 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
   m_PrefabInstance: {fileID: 1573726935}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2000383819
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000383820}
+  - component: {fileID: 2000383821}
+  m_Layer: 0
+  m_Name: Virtual Camera (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2000383820
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000383819}
+  m_LocalRotation: {x: 0.007949913, y: 0.9916421, z: 0.10421179, w: -0.07564853}
+  m_LocalPosition: {x: 163.3092, y: 30.357727, z: 528.19946}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1666752482}
+  m_Father: {fileID: 1417995265}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: -18.435, z: 161.265}
+--- !u!114 &2000383821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000383819}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 1382102154}
+  m_Follow: {fileID: 1382102154}
+  m_Lens:
+    FieldOfView: 60.000004
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 1666752482}
 --- !u!1001 &2007345852
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19153,7 +20815,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 108507113624698413, guid: eebb56c82efbd8d4bb0eb6bd925a0e9d, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 108507113624698413, guid: eebb56c82efbd8d4bb0eb6bd925a0e9d, type: 3}
       propertyPath: m_LocalScale.x
@@ -19493,8 +21155,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2052544694}
-  m_LocalRotation: {x: 0.26932633, y: -0.0023905032, z: 0.0006685304, w: 0.96304584}
-  m_LocalPosition: {x: 0.02618116, y: 7, z: -5.273693}
+  m_LocalRotation: {x: 0.25365776, y: 1.088941e-14, z: -2.8555776e-15, w: 0.96729404}
+  m_LocalPosition: {x: 0, y: 6.9948897, z: -4.401444}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -20456,18 +22118,46 @@ PrefabInstance:
     - target: {fileID: 3028419032764210389, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
       propertyPath: virtualCamera
       value: 
-      objectReference: {fileID: 467121502}
+      objectReference: {fileID: 2052544694}
     - target: {fileID: 3183292463359279335, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
       propertyPath: m_Camera
       value: 
-      objectReference: {fileID: 467121505}
+      objectReference: {fileID: 2052544696}
+    - target: {fileID: 4072204819620859382, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
+      propertyPath: mixingCamera
+      value: 
+      objectReference: {fileID: 1417995266}
+    - target: {fileID: 4072204819620859382, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
+      propertyPath: sectorName.Array.size
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4072204819620859382, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
+      propertyPath: sectorName.Array.data[0]
+      value: Sector1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4072204819620859382, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
+      propertyPath: sectorName.Array.data[1]
+      value: Sector2Left
+      objectReference: {fileID: 0}
+    - target: {fileID: 4072204819620859382, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
+      propertyPath: sectorName.Array.data[2]
+      value: Sector2Center
+      objectReference: {fileID: 0}
+    - target: {fileID: 4072204819620859382, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
+      propertyPath: sectorName.Array.data[3]
+      value: Sector2Right
+      objectReference: {fileID: 0}
+    - target: {fileID: 4072204819620859382, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
+      propertyPath: sectorName.Array.data[4]
+      value: Sector3
+      objectReference: {fileID: 0}
     - target: {fileID: 6184185812792942562, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
       propertyPath: m_Name
       value: PlayerPrefeb
       objectReference: {fileID: 0}
     - target: {fileID: 6239542640175349213, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 6239542640175349213, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Player/CameraChange.cs
+++ b/Assets/Scripts/Player/CameraChange.cs
@@ -6,32 +6,21 @@ using Cinemachine;
 public class CameraChange : MonoBehaviour
 {
     [SerializeField] CinemachineMixingCamera mixingCamera;
+    [SerializeField] List<string> sectorName;
     int currentCamera = 0;
     void OnTriggerEnter(Collider other)
     {
-        if (other.name == "RoomSector" && currentCamera != 1)
+        for (int i = 0; i < sectorName.Count; i++)
         {
-            CameraInit();
-            StopAllCoroutines();
-            StartCoroutine(LerpCamera(currentCamera, 1));
+            if (other.name == sectorName[i] && currentCamera != i)
+            {
+                CameraInit();
+                StopAllCoroutines();
+                StartCoroutine(LerpCamera(currentCamera, i));
 
-            currentCamera = 1;
-        }
-        else if (other.name == "TrackSector1" && currentCamera != 0)
-        {
-            CameraInit();
-            StopAllCoroutines();
-            StartCoroutine(LerpCamera(currentCamera, 0));
-
-            currentCamera = 0;
-        }
-        else if (other.name == "TrackSector2" && currentCamera != 2)
-        {
-            CameraInit();
-            StopAllCoroutines();
-            StartCoroutine(LerpCamera(currentCamera, 2));
-
-            currentCamera = 2;
+                currentCamera = i;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
# 숲 맵 카메라 설정 및 프리팹 태그 수정 후 파티클 적용

## Related Issue(s)
없음

## PR Description
#### 1. 숲 맵 카메라 완성
숲 맵에서 카메라를 조정하고 경로 선택에 따라 카메라가 자동으로 바뀌도록 하였습니다. CameraChange.cs 코드를 재사용할 수 있도록 조금 수정했습니다.

#### 2. 숲 맵에 파티클 적용
만들었던 파티클을 숲 맵에 적용했습니다.

#### 3. 프리팹 태그 수정
콜라이더가 있는 오브젝트가 아닌 부모 오브젝트가 태그를 가진 경우가 있어 콜라이더를 가진 오브젝트의 태그를 수정했습니다. 

### Changes Included

- [x] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation

### Screenshots (if UI changes were made)
![image](https://github.com/user-attachments/assets/379bd25d-5e3f-433a-91d5-2240763ca882)
![image](https://github.com/user-attachments/assets/80a7ab6c-eedd-42b4-b8df-96349bf70346)

### Notes for Reviewer
코드는 CameraChange.cs 코드만 수정했으니 코드는 이것만 보시면 될 것 같습니다.

---

## Reviewer Checklist

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Code review comments have been addressed or clarified.

---

## Additional Comments
혹시 추가로 필요한 사진이 있으시면 말씀해주세요.
