### PR TITLE
[동굴 맵] 평지 <-> 다운힐 충돌 문제 해결

### DIFF
--- a/Assets/Scenes/CaveMap.unity
+++ b/Assets/Scenes/CaveMap.unity
@@ -5683,8 +5683,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 350, y: 2, z: 356}
-  m_Center: {x: 0, y: -1, z: 30}
+  m_Size: {x: 350, y: 2, z: 300}
+  m_Center: {x: -150, y: -1, z: -134.05}
 --- !u!4 &171241949
 Transform:
   m_ObjectHideFlags: 0
@@ -5693,7 +5693,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 171241947}
   m_LocalRotation: {x: -0, y: 0.38268343, z: -0, w: 0.92387956}
-  m_LocalPosition: {x: -35.200012, y: 0, z: 6.800003}
+  m_LocalPosition: {x: 165.03682, y: -0.1282655, z: 77.98255}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -33988,7 +33988,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1163592518}
   m_LocalRotation: {x: 0.20440894, y: 0.37319937, z: -0.08466896, w: 0.900983}
-  m_LocalPosition: {x: 227.5, y: -34.3, z: 140.5}
+  m_LocalPosition: {x: 227.38081, y: -34.651054, z: 140.32652}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -34006,8 +34006,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 20, y: 1.9999996, z: 163.5123}
-  m_Center: {x: 0.00000011142081, y: -1.899996, z: 2.043846}
+  m_Size: {x: 20, y: 1.9999996, z: 159.9}
+  m_Center: {x: 0, y: -1, z: 0}
 --- !u!4 &1164267014 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6670234744341657123, guid: c79d59d66358e0f45a098f4b8a82f8be, type: 3}

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -1,7 +1,7 @@
 {
-  "m_Name": "Settings",
-  "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
-  "m_Dictionary": {
-    "m_DictionaryValues": []
-  }
+    "m_Name": "Settings",
+    "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
+    "m_Dictionary": {
+        "m_DictionaryValues": []
+    }
 }


### PR DESCRIPTION
# [동굴 맵] 평지 <-> 다운힐 충돌 문제 해결

## Related Issue(s)

없음.

## PR Description

평지 <-> 다운힐 로 지형이 바뀔때 짱구가 걸리듯이 위로 튀어오르는 충돌 문제를 해결하였다. 
CaveMap > Collider > 1_GroundCollider 와 2_DownHill Collider 을 수정하였다. 

### Changes Included

- [x] Fixed identified bug(s): 동굴 맵에서 평지->다운힐 구간의 충돌 문제 해결

### Screenshots (if UI changes were made)

![image](https://github.com/user-attachments/assets/56bfa719-92f8-470e-8665-1bb34ef6d110)

### Notes for Reviewer

동굴 맵 플레이 해보시면서 충돌 문제가 해결됐는지 확인해주시면 감사하겠습니다.
평지에서 다운힐로 갈때 짱구가 위로 튀는지 확인해주시면 됩니다. (제가 확인했을때는 문제 없었습니다!)

---

## Reviewer Checklist

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

---

## Additional Comments

본 PR의 실제 작업시간은 12분 정도 걸렸습니다. (0.2 hour)
