### PR TITLE
[동굴, 숲 맵] 시작 지점 콜라이더 추가

### DIFF
--- a/Assets/Scenes/CaveMap.unity
+++ b/Assets/Scenes/CaveMap.unity
@@ -1075,7 +1075,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2007,7 +2007,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2546,7 +2546,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2909,7 +2909,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3597,7 +3597,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4439393411831265753, guid: 9a2d1c127d5c7bd43a3b771ba4ec845f, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4439393411831265753, guid: 9a2d1c127d5c7bd43a3b771ba4ec845f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4734,7 +4734,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4955,7 +4955,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_LocalScale.x
@@ -7624,7 +7624,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6670234744341657123, guid: c79d59d66358e0f45a098f4b8a82f8be, type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 6670234744341657123, guid: c79d59d66358e0f45a098f4b8a82f8be, type: 3}
       propertyPath: m_LocalScale.x
@@ -7694,7 +7694,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8171,7 +8171,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Path: {fileID: 1847862510}
-  m_PathPosition: 0.15
+  m_PathPosition: 0.248
   m_PositionUnits: 0
   m_PathOffset: {x: 0, y: 0, z: 0}
   m_XDamping: 0
@@ -8264,7 +8264,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 25
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8808,7 +8808,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10201,7 +10201,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_LocalScale.x
@@ -12101,7 +12101,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12448,7 +12448,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12755,7 +12755,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 38
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14127,7 +14127,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1565784314003400054, guid: 9d96437b1954fd74c84a5e1999bb2cb1, type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 1565784314003400054, guid: 9d96437b1954fd74c84a5e1999bb2cb1, type: 3}
       propertyPath: m_LocalScale.x
@@ -14790,7 +14790,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 568653527279986074, guid: c65426a375c90574a95eaaf4840e9481, type: 3}
       propertyPath: m_RootOrder
-      value: 24
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 568653527279986074, guid: c65426a375c90574a95eaaf4840e9481, type: 3}
       propertyPath: m_LocalScale.x
@@ -16138,7 +16138,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -17317,7 +17317,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -18117,7 +18117,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5125010707129076267, guid: 616fdaa7dbff40e4f91c695be15f9f4f, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 5125010707129076267, guid: 616fdaa7dbff40e4f91c695be15f9f4f, type: 3}
       propertyPath: m_LocalScale.x
@@ -18458,7 +18458,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_LocalScale.x
@@ -18761,7 +18761,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8204406447206829204, guid: 0c837400ef1130c4196d20ee30637d9c, type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 8204406447206829204, guid: 0c837400ef1130c4196d20ee30637d9c, type: 3}
       propertyPath: m_LocalScale.x
@@ -18916,7 +18916,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 644256399}
   m_LocalRotation: {x: 0.10386894, y: -0.000000029641125, z: 0.000000003095536, w: 0.994591}
-  m_LocalPosition: {x: -317.98898, y: 57.920044, z: -222.96873}
+  m_LocalPosition: {x: -317.98898, y: 57.920044, z: -220.02873}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -19187,7 +19187,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8204406447206829204, guid: 0c837400ef1130c4196d20ee30637d9c, type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 8204406447206829204, guid: 0c837400ef1130c4196d20ee30637d9c, type: 3}
       propertyPath: m_LocalScale.x
@@ -20030,7 +20030,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 23
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -20405,7 +20405,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -23781,7 +23781,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 22
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -24551,7 +24551,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25508,7 +25508,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -26441,7 +26441,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_LocalScale.x
@@ -26897,7 +26897,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -27290,7 +27290,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6670234744341657123, guid: c79d59d66358e0f45a098f4b8a82f8be, type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6670234744341657123, guid: c79d59d66358e0f45a098f4b8a82f8be, type: 3}
       propertyPath: m_LocalScale.x
@@ -27380,7 +27380,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -27993,7 +27993,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -28126,7 +28126,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8204406447206829204, guid: 0c837400ef1130c4196d20ee30637d9c, type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 8204406447206829204, guid: 0c837400ef1130c4196d20ee30637d9c, type: 3}
       propertyPath: m_LocalScale.x
@@ -28366,7 +28366,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 33
+      value: 32
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -30683,7 +30683,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 31
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -32308,7 +32308,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6182452670827713600, guid: cfb04594231799d4092ee0064447ce94, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 6182452670827713600, guid: cfb04594231799d4092ee0064447ce94, type: 3}
       propertyPath: m_LocalScale.x
@@ -32503,7 +32503,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 32
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -33576,7 +33576,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_LocalScale.x
@@ -34309,7 +34309,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6239542640175349213, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 2.94
       objectReference: {fileID: 0}
     - target: {fileID: 6239542640175349213, guid: 8e830a4524212b44299a5fbdf916dda9, type: 3}
       propertyPath: m_LocalRotation.w
@@ -35845,7 +35845,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 522926820628845222, guid: 2f3f7d4927009b84583c02fcbc509217, type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 522926820628845222, guid: 2f3f7d4927009b84583c02fcbc509217, type: 3}
       propertyPath: m_LocalScale.x
@@ -36743,7 +36743,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -39109,7 +39109,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 35
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -39502,7 +39502,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1405780256}
-  m_LocalRotation: {x: 0.08195217, y: 0.88103527, z: 0.16583712, w: -0.4353835}
+  m_LocalRotation: {x: 0.08243122, y: 0.8799898, z: 0.16583982, w: -0.43740177}
   m_LocalPosition: {x: 90.01102, y: -9.079956, z: 93.531265}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -39615,7 +39615,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 36
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -41815,7 +41815,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_LocalScale.x
@@ -42734,7 +42734,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1486896499}
   m_LocalRotation: {x: 0.10386894, y: -0.000000029641125, z: 0.000000003095536, w: 0.994591}
-  m_LocalPosition: {x: 0, y: -1.5, z: -4.5000005}
+  m_LocalPosition: {x: 0, y: -1.5, z: -1.5599997}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -43812,7 +43812,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -44312,7 +44312,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_LocalScale.x
@@ -45583,7 +45583,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5125010707129076267, guid: 616fdaa7dbff40e4f91c695be15f9f4f, type: 3}
       propertyPath: m_RootOrder
-      value: 25
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 5125010707129076267, guid: 616fdaa7dbff40e4f91c695be15f9f4f, type: 3}
       propertyPath: m_LocalScale.x
@@ -47496,7 +47496,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 40
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -47943,7 +47943,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -48484,7 +48484,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -50222,7 +50222,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 37
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -51105,7 +51105,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -51912,7 +51912,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -52444,7 +52444,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_LocalScale.x
@@ -54584,7 +54584,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -56315,7 +56315,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_RootOrder
-      value: 22
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 2559810838395413726, guid: e37d55d9adae8724c9dcf1dff5b67578, type: 3}
       propertyPath: m_LocalScale.x
@@ -57144,7 +57144,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1972625976}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 4, z: -4}
+  m_LocalPosition: {x: 0, y: 4, z: 2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -57671,7 +57671,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8204406447206829204, guid: 0c837400ef1130c4196d20ee30637d9c, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 8204406447206829204, guid: 0c837400ef1130c4196d20ee30637d9c, type: 3}
       propertyPath: m_LocalScale.x
@@ -58668,7 +58668,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 24
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -59253,7 +59253,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 568653527279986074, guid: c65426a375c90574a95eaaf4840e9481, type: 3}
       propertyPath: m_RootOrder
-      value: 23
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 568653527279986074, guid: c65426a375c90574a95eaaf4840e9481, type: 3}
       propertyPath: m_LocalScale.x
@@ -60313,7 +60313,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 34
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -61980,7 +61980,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -63667,7 +63667,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4439393411831265753, guid: 9a2d1c127d5c7bd43a3b771ba4ec845f, type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 4439393411831265753, guid: 9a2d1c127d5c7bd43a3b771ba4ec845f, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/CaveMap.unity
+++ b/Assets/Scenes/CaveMap.unity
@@ -322,7 +322,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &15238184
 PrefabInstance:
@@ -1075,7 +1075,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2007,7 +2007,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2546,7 +2546,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2909,7 +2909,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3597,7 +3597,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4439393411831265753, guid: 9a2d1c127d5c7bd43a3b771ba4ec845f, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4439393411831265753, guid: 9a2d1c127d5c7bd43a3b771ba4ec845f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4734,7 +4734,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -7694,7 +7694,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8264,7 +8264,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 24
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -8808,7 +8808,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12101,7 +12101,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 38
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12448,7 +12448,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12755,7 +12755,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 37
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -13339,7 +13339,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &431316873
 PrefabInstance:
@@ -16138,7 +16138,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -17317,7 +17317,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -20030,7 +20030,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 22
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -20405,7 +20405,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -23781,7 +23781,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -24551,7 +24551,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25508,7 +25508,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 25
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -26897,7 +26897,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -27380,7 +27380,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -27993,7 +27993,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -28366,7 +28366,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 32
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -30683,7 +30683,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -32503,7 +32503,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 31
+      value: 32
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -36743,7 +36743,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -39109,7 +39109,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 34
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -39615,7 +39615,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 35
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -43812,7 +43812,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -47496,7 +47496,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -47943,7 +47943,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 365056431892884558, guid: caf1535fbda151d4f9ac0ed3d9fd219f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -48484,7 +48484,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -50222,7 +50222,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_RootOrder
-      value: 36
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 1519876469170990761, guid: 5845f049f3856a34486f285c6897b7c2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -51105,7 +51105,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -51912,7 +51912,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -54584,7 +54584,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -57106,6 +57106,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0c837400ef1130c4196d20ee30637d9c, type: 3}
+--- !u!1 &1972625976
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1972625978}
+  - component: {fileID: 1972625977}
+  m_Layer: 3
+  m_Name: StartWallCollider
+  m_TagString: Wall
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1972625977
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1972625976}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 14, y: 10, z: 2}
+  m_Center: {x: 0, y: 0, z: -1}
+--- !u!4 &1972625978
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1972625976}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 4, z: -4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1973903872 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6670234744341657123, guid: c79d59d66358e0f45a098f4b8a82f8be, type: 3}
@@ -58623,7 +58668,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_RootOrder
-      value: 23
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 3539824668110437032, guid: 162c6c70c3f47c94ba0acb5908ba3cd3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -58988,11 +59033,12 @@ MonoBehaviour:
   serverIp: 10.150.196.21
   isRun: 0
   runTime: 0
+  nickname: 
   hasSubmitted: 0
   ranking:
     Map1: []
     Map2: []
-  firstGame: 1
+  isFirstGame: 1
 --- !u!4 &2060162596
 Transform:
   m_ObjectHideFlags: 0
@@ -60267,7 +60313,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_RootOrder
-      value: 33
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 2968306919757391886, guid: aa5dab1711bb30243871c64a983fe59b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -61934,7 +61980,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3187934514806870755, guid: 94b49611a343f2e44ace4999d186c86d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -63621,7 +63667,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4439393411831265753, guid: 9a2d1c127d5c7bd43a3b771ba4ec845f, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 4439393411831265753, guid: 9a2d1c127d5c7bd43a3b771ba4ec845f, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/ForestMap.unity
+++ b/Assets/Scenes/ForestMap.unity
@@ -18198,11 +18198,12 @@ MonoBehaviour:
   serverIp: 192.168.245.36
   isRun: 0
   runTime: 0
+  nickname: 
   hasSubmitted: 0
   ranking:
     Map1: []
     Map2: []
-  firstGame: 1
+  isFirstGame: 1
 --- !u!114 &1056385605
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20126,11 +20127,12 @@ MonoBehaviour:
   serverIp: 10.150.196.21
   isRun: 0
   runTime: 0
+  nickname: 
   hasSubmitted: 0
   ranking:
     Map1: []
     Map2: []
-  firstGame: 1
+  isFirstGame: 1
 --- !u!4 &1182443906
 Transform:
   m_ObjectHideFlags: 0
@@ -28263,6 +28265,51 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 38335279662569219, guid: 34d3f526198dae440bb2ce6005d86055, type: 3}
   m_PrefabInstance: {fileID: 1655150827}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1657271026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1657271028}
+  - component: {fileID: 1657271027}
+  m_Layer: 0
+  m_Name: StartWallCollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1657271027
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1657271026}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 30, y: 12, z: 2}
+  m_Center: {x: 0, y: 0, z: -1}
+--- !u!4 &1657271028
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1657271026}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1661085430 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2546592871699326495, guid: 9366b62bb219d8a4d98a0bf7deaa2759, type: 3}
@@ -33463,7 +33510,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2016589553
 GameObject:

--- a/Assets/Scenes/ForestMap.unity
+++ b/Assets/Scenes/ForestMap.unity
@@ -3027,7 +3027,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Path: {fileID: 1312869645}
-  m_PathPosition: -0.019492269
+  m_PathPosition: 0.98050773
   m_PositionUnits: 0
   m_PathOffset: {x: 0, y: 0, z: 0}
   m_XDamping: 0
@@ -3173,7 +3173,7 @@ Transform:
   - {fileID: 1476160509}
   - {fileID: 1525773533}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &171755028
 GameObject:
@@ -7647,7 +7647,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &441058814
 PrefabInstance:
@@ -8160,8 +8160,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 467121502}
-  m_LocalRotation: {x: 0.25751257, y: -5.5154835e-12, z: -2.6458282e-11, w: 0.966275}
-  m_LocalPosition: {x: 8.309197, y: 130.35773, z: -486.80054}
+  m_LocalRotation: {x: 0.2239495, y: 0.000000005378685, z: -0.0000000012359458, w: 0.9746008}
+  m_LocalPosition: {x: 8.309197, y: 130.35773, z: -487.3853}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -8666,7 +8666,7 @@ Transform:
   - {fileID: 12613162}
   - {fileID: 2034264902}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &487937727
 PrefabInstance:
@@ -11552,7 +11552,7 @@ Transform:
   - {fileID: 2093031541}
   - {fileID: 2120034250}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &617623333
 PrefabInstance:
@@ -11982,7 +11982,7 @@ Transform:
   - {fileID: 1254450306}
   - {fileID: 1417995265}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &649261746
 PrefabInstance:
@@ -16396,8 +16396,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 30, y: 2, z: 9.9}
-  m_Center: {x: 0, y: -1, z: 0}
+  m_Size: {x: 30, y: 2, z: 29.8}
+  m_Center: {x: 0, y: -1, z: -10}
 --- !u!1 &959042944
 GameObject:
   m_ObjectHideFlags: 0
@@ -20146,7 +20146,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1194166504
 PrefabInstance:
@@ -21641,6 +21641,9 @@ MonoBehaviour:
     width: 0.2
   m_Looped: 0
   m_Waypoints:
+  - position: {x: 0, y: 0, z: -35}
+    tangent: {x: 0, y: 0, z: 10}
+    roll: 0
   - position: {x: 0, y: 0, z: -5}
     tangent: {x: 0, y: 0, z: 10}
     roll: 0
@@ -22315,7 +22318,7 @@ Transform:
   m_Children:
   - {fileID: 171755029}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1356948802
 PrefabInstance:
@@ -24059,7 +24062,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!4 &1427066195 stripped
 Transform:
@@ -26560,6 +26563,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3299447644466322948, guid: 2435df58606d18e4d83f614e23d78b6b, type: 3}
   m_PrefabInstance: {fileID: 403972658}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1567085448
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2086594211926230867, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_Name
+      value: 2x1 Straight
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.00000011920929
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.220446e-16
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -20
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5616489773431274127, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1a868d2c258dd44479ab216d0669e9b6, type: 3}
 --- !u!4 &1567631665 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3500581970453440516, guid: 3286f81238c0c07409e6cf14ca23ca3d, type: 3}
@@ -28277,7 +28337,7 @@ GameObject:
   - component: {fileID: 1657271027}
   m_Layer: 0
   m_Name: StartWallCollider
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -28308,7 +28368,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1661085430 stripped
 Transform:
@@ -33510,7 +33570,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2016589553
 GameObject:
@@ -34102,8 +34162,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2052544694}
-  m_LocalRotation: {x: 0.25751257, y: -5.5154835e-12, z: -2.6458282e-11, w: 0.966275}
-  m_LocalPosition: {x: 0, y: 7, z: -5}
+  m_LocalRotation: {x: 0.2239495, y: 0.000000005378685, z: -0.0000000012359458, w: 0.9746008}
+  m_LocalPosition: {x: 0, y: 7, z: -5.5847683}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION
# [동굴, 숲 맵] 시작 지점 콜라이더 추가

## Related Issue(s)

없음.

## PR Description

동굴 맵과 숲 맵의 각 시작 지점에 투명벽을 배치하였다.
시작 지점에서 뒤로 가면서 트랙 밖으로 빠져나가는 문제를 수정하였다.

동굴 시작 지점과 짱구를 트랙 진행방향쪽으로 조금 당겨 트랙 밖이 보이는 문제를 해결하였다.
숲 맵의 시작 지점 이전에도 숲 타일을 하나 추가로 깔아서, 뒤로 갔을때 트랙 밖이 보이는 문제를 해결하였다.

### Changes Included

- [ ] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation

### Screenshots (if UI changes were made)

1. 동굴 맵의 StartWallCollider Object
![image](https://github.com/user-attachments/assets/1aae94a0-d0f0-485d-b93d-0f2420a9037b)
![image](https://github.com/user-attachments/assets/bbdac57f-f227-4b65-8816-914655234551)

2. 숲 맵의 StartWallCollider Object
![image](https://github.com/user-attachments/assets/e1a3c7ba-4f18-404a-9432-0cd2e48e1e6f)
![image](https://github.com/user-attachments/assets/f47285ae-8dd8-4f9b-9ba7-07330b54b3bb)


### Notes for Reviewer

간단한 WallCollider 작업입니당.

---

## Reviewer Checklist

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

---

## Additional Comments

없음.