### PR TITLE
메테리얼 버그 수정

### DIFF
--- a/Assets/MapResources/Plane/For Covering.mat
+++ b/Assets/MapResources/Plane/For Covering.mat
@@ -75,6 +75,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.3443841, g: 0.6698113, b: 0.5472536, a: 1}
+    - _Color: {r: 0.28369123, g: 0.55345905, b: 0.31366545, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Materials/Sky.mat
+++ b/Assets/Materials/Sky.mat
@@ -107,6 +107,6 @@ Material:
     m_Colors:
     - _Color: {r: 1, g: 0.10015053, b: 0, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _GroundColor: {r: 0.2811499, g: 0.509434, b: 0.38830364, a: 1}
+    - _GroundColor: {r: 0.29405478, g: 0.5283019, b: 0.31325534, a: 1}
     - _SkyTint: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Materials/Transparent.mat
+++ b/Assets/Materials/Transparent.mat
@@ -8,16 +8,15 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Transparent
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ValidKeywords:
+  m_Shader: {fileID: 10764, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords:
   - _ALPHAPREMULTIPLY_ON
-  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3000
-  stringTagMap:
-    RenderType: Transparent
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -61,11 +60,12 @@ Material:
     m_Ints: []
     m_Floats:
     - _BumpScale: 1
+    - _ColorMask: 15
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 10
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
+    - _GlossMapScale: 0
+    - _Glossiness: 0
     - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 3
@@ -74,9 +74,16 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
     - _UVSec: 0
+    - _UseUIAlphaClip: 0
     - _ZWrite: 0
     m_Colors:
-    - _Color: {r: 0.8773585, g: 0.8483891, b: 0.8483891, a: 0}
+    - _Color: {r: 1, g: 1, b: 1, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Specular: {r: 0, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []


### PR DESCRIPTION
# 메테리얼 버그 수정

## Related Issue(s)
X

## PR Description
1. 라인 메테리얼이 완전히 투명하지 않던 버그 수정
2. 숲 맵의 멀리에 있는 메테리얼의 색 통일

### Changes Included

- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation

### Screenshots (if UI changes were made)
![image](https://github.com/user-attachments/assets/93da67c2-3ed3-45b0-babe-f794ea34b1a6)

### Notes for Reviewer
X

---

## Reviewer Checklist
X

---

## Additional Comments
X
